### PR TITLE
Spanish I18n

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,20 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :null_session
+
+  before_action :set_locale
+
+  private
+
+    def set_locale
+      if params[:locale].present?
+        I18n.locale = params[:locale]
+      else
+        I18n.locale = I18n.default_locale
+      end
+    end
+
+    def default_url_options(options = {})
+      { locale: I18n.locale }
+    end
 end

--- a/app/controllers/switchboards_controller.rb
+++ b/app/controllers/switchboards_controller.rb
@@ -2,14 +2,28 @@ class SwitchboardsController < ApplicationController
   # POST switchboards/welcome
   def welcome
     response = Twilio::TwiML::VoiceResponse.new
-    response.gather(num_digits: '5', action: switchboards_representatives_path, timeout: 20) do |gather|
+    response.gather(num_digits: '5', action: switchboards_enter_zipcode_path, timeout: 20, actionOnEmptyResult: true) do |gather|
       alice_says(
         requester: gather,
         message: t('.intro'),
       )
       alice_says(
         requester: gather,
-        message: t('.prompt'),
+        message: t('.language_prompt'),
+      )
+    end
+
+    render xml: response.to_s
+  end
+
+  # POST switchboards/enter_zipcode
+  def enter_zipcode
+    set_locale_after_prompt
+    response = Twilio::TwiML::VoiceResponse.new
+    response.gather(num_digits: '5', action: switchboards_representatives_path, timeout: 20) do |gather|
+      alice_says(
+        requester: gather,
+        message: t('.zipcode_prompt'),
       )
     end
 
@@ -73,7 +87,16 @@ class SwitchboardsController < ApplicationController
     def alice_says(requester: , message:)
       requester.say(
         message: message,
-        voice: 'alice'
+        voice: 'alice',
+        language: I18n.locale.to_s
       )
+    end
+
+    def set_locale_after_prompt
+      if params[:Digits] == '2'
+        I18n.locale = :es
+      else
+        I18n.locale = I18n.default_locale
+      end
     end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,10 +29,19 @@
                     pages_about_path, class: 'nav-link' %>
             </li>
           </ul>
-          <%# <form class="form-inline mt-2 mt-md-0">
-            <input class="form-control mr-sm-2" type="text" placeholder="Search" aria-label="Search">
-            <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
-          </form> %>
+
+          <ul class="navbar-nav ml-md-auto">
+            <li class="nav-item dropdown">
+              <a class="nav-item nav-link dropdown-toggle mr-md-2" href="#" id="byc-locales" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <%= I18n.locale %>
+              </a>
+              <div class="dropdown-menu dropdown-menu-md-right" aria-labelledby="byc-locales">
+                <%= link_to 'English', { locale: 'en' }, class: 'dropdown-item' %>
+                <div class="dropdown-divider"></div>
+                <%= link_to 'Español', { locale: 'es' }, class: 'dropdown-item' %>
+              </div>
+            </li>
+          </ul>
         </div>
       </nav>
     </header>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,9 @@ en:
   switchboards:
     welcome:
       intro: Thanks for using Bug Your Congressman dot com.
-      prompt:
+      language_prompt: Para espanol o prima dos.
+    enter_zipcode:
+      zipcode_prompt:
         Please enter your 5 digit zipcode to get a list of representatives you
         can call.
     representatives:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,8 +51,7 @@ en:
       footer:
         attributes_html:
           The code for this site is public on
-          <a href="https://github.com/frankolson/bugyourcongressman">GitHub
-          </a>.
+          <a href="https://github.com/frankolson/bugyourcongressman">GitHub</a>.
   pages:
     home:
       instructions:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,7 +2,9 @@ es:
   switchboards:
     welcome:
       intro: Gracias por utilizar Bug Your Congressman dog com.
-      prompt:
+      language_prompt: Para espanol o prima dos.
+    enter_zipcode:
+      zipcode_prompt:
         Por favor, marque los cinco números del código postal para recibir una
         lista de representantes a que Usted puede llamar.
     representatives:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -20,8 +20,7 @@ es:
       footer:
         attributes_html:
           El código para este sitio es público en
-          <a href="https://github.com/frankolson/bugyourcongressman">GitHub
-          </a>.
+          <a href="https://github.com/frankolson/bugyourcongressman">GitHub</a>.
   pages:
     home:
       instructions:
@@ -65,7 +64,7 @@ es:
         authors: Amir H. Ali y Emily Clark en
         summary_html:
           'En otras palabras, solo si se puede probar que un policía violó sus
-          derechos, … y …. además que a otro policía le han demandado con éxito
+          derechos, <em>y</em> además que a otro policía le han demandado con éxito
           la misma violación, es probable que el caso se desestimará. Aquí se
           demuestra otro ejemplo claro de lo que significa:'
       resolution_link_title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,12 @@
 Rails.application.routes.draw do
   post 'switchboards/welcome', to: 'switchboards#welcome'
-  post 'switchboards/representatives', to: 'switchboards#representatives'
-  post 'switchboards/no_zipcode', to: 'switchboards#no_zipcode'
-  post 'switchboards/dial', to: 'switchboards#dial'
+  post 'switchboards/enter_zipcode', to: 'switchboards#enter_zipcode'
 
   scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do
+    post 'switchboards/representatives', to: 'switchboards#representatives'
+    post 'switchboards/no_zipcode', to: 'switchboards#no_zipcode'
+    post 'switchboards/dial', to: 'switchboards#dial'
+
     get 'pages/about'
     root 'pages#home'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
   post 'switchboards/no_zipcode', to: 'switchboards#no_zipcode'
   post 'switchboards/dial', to: 'switchboards#dial'
 
-  get 'pages/about'
-  root 'pages#home'
+  scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do
+    get 'pages/about'
+    root 'pages#home'
+  end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/test/controllers/switchboard_controller_test.rb
+++ b/test/controllers/switchboard_controller_test.rb
@@ -16,7 +16,14 @@ class SwitchboardControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select 'Say', I18n.t('switchboards.welcome.intro')
-    assert_select 'Say', I18n.t('switchboards.welcome.prompt')
+    assert_select 'Say', I18n.t('switchboards.welcome.language_prompt')
+  end
+
+  test "should post enter_zipcode" do
+    post switchboards_enter_zipcode_url
+
+    assert_response :success
+    assert_select 'Say', I18n.t('switchboards.enter_zipcode.zipcode_prompt')
   end
 
   test "should post representatives with results" do


### PR DESCRIPTION
## A picture tells a thousand words
<img width="1792" alt="Screen Shot 2020-06-08 at 11 52 16 PM" src="https://user-images.githubusercontent.com/6773706/84115600-2c0de580-a9e3-11ea-8532-6158eeb5792c.png">
<img width="1792" alt="Screen Shot 2020-06-08 at 11 52 23 PM" src="https://user-images.githubusercontent.com/6773706/84115613-2fa16c80-a9e3-11ea-93ad-a935d69f8059.png">

## What was done
- Language picker added to navigation menu
- Spanish added as a supported language for both the static pages and phone tree