### PR TITLE
Update civic_information gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/frankolson/ruby-civic-information
-  revision: e9a29eef972711f30ea0ddd8305235546be07df0
+  revision: 4fe796a4cee8d1af0898fb8373a8e1d7351b7230
   branch: master
   specs:
     civic_information (0.1.0)

--- a/app/controllers/switchboards_controller.rb
+++ b/app/controllers/switchboards_controller.rb
@@ -56,7 +56,10 @@ class SwitchboardsController < ApplicationController
   # POST switchboards/dial
   def dial
     user_zipcode = params[:zipcode] # somehow need to persist this between representatives and dial
-    members_of_congress = CivicInformation::Representative.where(address: user_zipcode)
+    members_of_congress = CivicInformation::Representative.where(
+      address: user_zipcode,
+      roles: ['legislatorLowerBody', 'legislatorUpperBody']
+    )
     member = members_of_congress[params[:Digits].to_i-1]
 
     response = Twilio::TwiML::VoiceResponse.new


### PR DESCRIPTION
## What was done
- The `civic_information` gem was updated, requiring roles to be passed in, instead of just inferring that requests always wanted legislators. This pull requests adjusts this app's usage of the gem to accommodate that change.

_Addresses issue #4_